### PR TITLE
Fixes for Arm architecture

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ repos:
     rev: stable
     hooks:
       - id: black
-        language_version: python3.6
+        language_version: python3
 
   - repo: https://gitlab.com/pycqa/flake8
     rev: 0c3b8045a7b51aec7abf19dea94d5292cebeeea0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,8 @@
 
 virtual environment and pre-commit hooks:
 ```bash
-python 3 -m venv venv && . venv/bin/activate && pip install -U pip
+python3 -m venv venv && . venv/bin/activate && pip install -U pip
+pip install -e .
 pip install pre-commit
 pre-commit install
 ```

--- a/cortex/ext/install_dependencies.sh
+++ b/cortex/ext/install_dependencies.sh
@@ -5,6 +5,7 @@ set -eu
 install_root=$PWD/cortex/ext
 mkdir -p $install_root
 
+arch_is_arm=$(dpkg --print-architecture | grep '^arm' | wc -l)
 
 #________________________ minimap2 _________________________#
 cd $install_root
@@ -12,7 +13,13 @@ minimap_version="v2.17"
 minimap_dir="minimap2_dir"
 if [[ ! -e "./${minimap_dir}" ]];then
   git clone https://github.com/lh3/minimap2 && mv minimap2 "$minimap_dir" 
-  cd "$minimap_dir" && git checkout "$minimap_version" && make
+  cd "$minimap_dir" && git checkout "$minimap_version"
+  if [[ $arch_is_arm -gt 0 ]]
+  then
+    make arm_neon=1 aarch64=1
+  else
+    make
+  fi
   cd .. && mv "${minimap_dir}/minimap2" . && rm -rf "$minimap_dir"
 fi
 


### PR DESCRIPTION
Fixes minimap2 compile for arm.
Tweaks to instructions for running tests etc, and relaxed pre-commit python version to be just 3 instead of 3.6.

If this all ok, will then change the version to 2.2.1 and make a new release.